### PR TITLE
[Task #34] - Add application parameters to client_credentials tokens - Fix mongodb issue

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ClientCredentials.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ClientCredentials.java
@@ -205,6 +205,7 @@ public class ClientCredentials implements Serializable {
         creds.status = ((Integer) map.get("status")).intValue();
         creds.created = (Long) map.get("created");
         creds.scope = (String) map.get("scope");
+        creds.applicationDetails = JSONUtils.convertStringToMap(map.get("applicationDetails").toString());
         return creds;
     }
 

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/ClientCredentialsTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/ClientCredentialsTest.java
@@ -40,6 +40,7 @@ public class ClientCredentialsTest {
         map.put("created", 1365191565324l);
         map.put("type", 1);
         map.put("status", 1);
+        map.put("applicationDetails", "{\"my\":\"param\"}");
 
         // WHEN
         ClientCredentials creds = ClientCredentials.loadFromMap(map);

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/MongoDBManagerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/MongoDBManagerTest.java
@@ -91,6 +91,8 @@ public class MongoDBManagerTest {
         map.put("created", 1365191565324l);
         map.put("type", 1);
         map.put("status", 1);
+        map.put("applicationDetails", "{\"my\":\"param\"}");
+
         willReturn(map).given(bson).toMap();
         willReturn(bson).given(dbManager).findObjectById(cred.getId(), MongoDBManager.ID_NAME,
                 MongoDBManager.CLIENTS_COLLECTION_NAME);


### PR DESCRIPTION
The client credentials details weren't properly retrieved when using mongodb for token storage.
