### PR TITLE
[Issue #52] When client_id or client_secret is missing on POST /oauth20/tokens, return "mandatory parameter client_id/client_secret is missing"

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/Response.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/Response.java
@@ -38,7 +38,7 @@ public final class Response {
     public static final String INVALID_CLIENT_CREDENTIALS = "{\"error\": \"invalid client_id/client_secret\"}";
     public static final String RESPONSE_TYPE_NOT_SUPPORTED = "{\"error\": \"unsupported_response_type\"}";
     public static final String INVALID_REDIRECT_URI = "{\"error\": \"invalid redirect_uri\"}";
-    public static final String MANDATORY_PARAM_MISSING = "{\"error\": \"mandatory paramater %s is missing\"}";
+    public static final String MANDATORY_PARAM_MISSING = "{\"error\": \"mandatory parameter %s is missing\"}";
     public static final String CANNOT_ISSUE_TOKEN = "{\"error\": \"cannot issue token\"}";
     public static final String INVALID_AUTH_CODE = "{\"error\": \"invalid auth_code\"}";
     public static final String GRANT_TYPE_NOT_SUPPORTED = "{\"error\": \"unsupported_grant_type\"}";

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/TokenRequest.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/TokenRequest.java
@@ -21,8 +21,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.util.CharsetUtil;
@@ -71,6 +73,11 @@ public class TokenRequest {
         this.redirectUri = params.get(REDIRECT_URI);
         this.clientId = params.get(CLIENT_ID);
         this.clientSecret = params.get(CLIENT_SECRET);
+        if (this.clientId == null && this.clientSecret == null) {
+            String [] clientCredentials = AuthorizationServer.getBasicAuthorizationClientCredentials(request);
+            this.clientId = clientCredentials [0];
+            this.clientSecret = clientCredentials [1];
+        }
         this.refreshToken = params.get(REFRESH_TOKEN);
         this.scope = params.get(SCOPE);
         this.username = params.get(USERNAME);
@@ -115,6 +122,10 @@ public class TokenRequest {
     protected void checkMandatoryParams() throws OAuthException {
         if (clientId == null || clientId.isEmpty()) {
             throw new OAuthException(String.format(Response.MANDATORY_PARAM_MISSING, CLIENT_ID),
+                    HttpResponseStatus.BAD_REQUEST);
+        }
+        if (clientSecret == null || clientSecret.isEmpty()) {
+            throw new OAuthException(String.format(Response.MANDATORY_PARAM_MISSING, CLIENT_SECRET),
                     HttpResponseStatus.BAD_REQUEST);
         }
         if (grantType == null || grantType.isEmpty()) {

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/AuthorizationServerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/AuthorizationServerTest.java
@@ -329,35 +329,6 @@ public class AuthorizationServerTest {
         verify(authServer).findAuthCode(any(TokenRequest.class));
     }
 
-//    @Test
-//    public void when_issue_token_extract_client_id() throws Exception {
-//        // GIVEN
-//        String clientId = "203598599234220";
-//        String clientSecret = "105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838";
-//        HttpRequest req = mock(HttpRequest.class);
-//        // 203598599234220:105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838
-//        String basicHeader = "Basic MjAzNTk4NTk5MjM0MjIwOjEwNWVmOTNlN2JiMzg2ZGEzYTIzYzMyZTg1NjM0MzRmYWQwMDVmZDBhNmE4ODMxNWZjZGY5NDZhYTc2MWM4Mzg=";
-//        HttpHeaders headers = new DefaultHttpHeaders();
-//        headers.set(HttpHeaders.Names.AUTHORIZATION, basicHeader);
-//        willReturn(headers).given(req).headers();
-//        String content = "redirect_uri=example.com"
-//                + "&grant_type=authorization_code&code=eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpq"
-//                + "NWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vAmJwoOh_ooe#ovaJVCOiZls_DzvkhOnRVrlDRSzZrbZIB_rwGXjpoeXdJlIjZQGhSR#";
-//        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
-//        given(req.getContent()).willReturn(buf);
-//        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
-//
-//        // WHEN
-//        try {
-//            authServer.issueAccessToken(req);
-//        } catch (OAuthException e) {
-//            // nothing to do
-//        }
-//
-//        // THEN
-//        verify(authServer, times(0)).getBasicAuthorizationClientCredentials(req);
-//    }
-
     @Test
     public void when_auth_code_not_valid_return_error() throws Exception {
         // GIVEN
@@ -930,23 +901,6 @@ public class AuthorizationServerTest {
         assertNull(result);
     }
 
-//    @Test
-//    public void when_revoke_token_get_client_id_from_req_header() throws Exception {
-//        // GIVEN
-//        HttpRequest req = mock(HttpRequest.class);
-//        willReturn(null).given(authServer).getBasicAuthorizationClientId(req);
-//
-//        // WHEN
-//        try {
-//            authServer.revokeToken(req);
-//        } catch (OAuthException e) {
-//            // do nothing
-//        }
-//
-//        // THEN
-//        verify(authServer).getBasicAuthorizationClientId(req);
-//    }
-
     @Test(expectedExceptions = OAuthException.class)
     public void when_revoke_token_with_client_id_null_will_throw_exception() throws Exception {
         // GIVEN
@@ -973,7 +927,6 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         willReturn(buf).given(req).getContent();
         willReturn(true).given(authServer).isExistingClient(clientId);
-        //willReturn(getAuthorizationBasicHeader()).given(req).headers();
 
         willReturn(null).given(authServer.db).findAccessToken(accessToken);
 
@@ -997,7 +950,6 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         willReturn(buf).given(req).getContent();
         willReturn(true).given(authServer).isExistingClient(clientId);
-        //willReturn(getAuthorizationBasicHeader()).given(req).headers();
 
         AccessToken dbAccessToken = mock(AccessToken.class);
         willReturn(true).given(dbAccessToken).tokenExpired();

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/AuthorizationServerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/AuthorizationServerTest.java
@@ -23,6 +23,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpStatus;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.codec.http.DefaultHttpHeaders;
 import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -47,6 +48,9 @@ import static org.testng.Assert.*;
 public class AuthorizationServerTest {
 
     AuthorizationServer authServer;
+    String clientId = "203598599234220";
+    String clientSecret = "105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838";
+
 
     @BeforeMethod
     public void setup() {
@@ -176,7 +180,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_valid_client_id_and_active_status_return_true() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         ClientCredentials creds = mock(ClientCredentials.class);
         given(creds.getStatus()).willReturn(ClientCredentials.ACTIVE_STATUS);
         given(authServer.db.findClientCredentials(clientId)).willReturn(creds);
@@ -191,7 +194,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_valid_client_id_and_inactive_status_return_true() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         ClientCredentials creds = mock(ClientCredentials.class);
         given(creds.getStatus()).willReturn(ClientCredentials.INACTIVE_STATUS);
         given(authServer.db.findClientCredentials(clientId)).willReturn(creds);
@@ -219,7 +221,6 @@ public class AuthorizationServerTest {
     public void when_issue_auth_code_validate_client_id() throws Exception {
         // GIVEN
         HttpRequest req = mock(HttpRequest.class);
-        String clientId = "203598599234220";
         given(authServer.db.findClientCredentials(clientId)).willReturn(
                 mock(ClientCredentials.class));
         given(req.getUri())
@@ -240,7 +241,6 @@ public class AuthorizationServerTest {
     public void when_issue_auth_code_invoke_generate_code() throws Exception {
         // GIVEN
         HttpRequest req = mock(HttpRequest.class);
-        String clientId = "203598599234220";
         ClientCredentials client = mock(ClientCredentials.class);
         given(client.getStatus()).willReturn(ClientCredentials.ACTIVE_STATUS);
         given(authServer.db.findClientCredentials(clientId)).willReturn(client);
@@ -262,7 +262,6 @@ public class AuthorizationServerTest {
     public void when_issue_token_and_client_id_not_the_same_as_token_return_error()
             throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         String redirectUri = "example.com";
 
         String authCode = "eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpqNWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vA"
@@ -270,13 +269,17 @@ public class AuthorizationServerTest {
         given(authServer.db.findAuthCode(authCode, redirectUri)).willReturn(mock(AuthCode.class));
 
         HttpRequest req = mock(HttpRequest.class);
+        // 203598599234220:105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838
+        String basicHeader = "Basic MjAzNTk4NTk5MjM0MjIwOjEwNWVmOTNlN2JiMzg2ZGEzYTIzYzMyZTg1NjM0MzRmYWQwMDVmZDBhNmE4ODMxNWZjZGY5NDZhYTc2MWM4Mzg=";
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set(HttpHeaders.Names.AUTHORIZATION, basicHeader);
+        willReturn(headers).given(req).headers();
         String content = "redirect_uri=" + redirectUri
                 + "&grant_type=authorization_code&code=eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpq"
                 + "NWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vAmJwoOh_ooe#ovaJVCOiZls_DzvkhOnRVrlDRSzZrbZIB_rwGXjpoeXdJlIjZQGhSR#";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         // WHEN
         String errorMsg = null;
@@ -294,7 +297,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_issue_token_validate_auth_code_and_client_id() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         String redirectUri = "example.com";
         ClientCredentials client = mock(ClientCredentials.class);
         given(client.getStatus()).willReturn(ClientCredentials.ACTIVE_STATUS);
@@ -307,13 +309,18 @@ public class AuthorizationServerTest {
         given(authServer.db.findAuthCode(code, redirectUri)).willReturn(authCode);
 
         HttpRequest req = mock(HttpRequest.class);
+        // 203598599234220:105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838
+        String basicHeader = "Basic MjAzNTk4NTk5MjM0MjIwOjEwNWVmOTNlN2JiMzg2ZGEzYTIzYzMyZTg1NjM0MzRmYWQwMDVmZDBhNmE4ODMxNWZjZGY5NDZhYTc2MWM4Mzg=";
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set(HttpHeaders.Names.AUTHORIZATION, basicHeader);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
         String content = "redirect_uri="
                 + redirectUri
                 + "&grant_type=authorization_code&code=eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpq"
                 + "NWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vAmJwoOh_ooe#ovaJVCOiZls_DzvkhOnRVrlDRSzZrbZIB_rwGXjpoeXdJlIjZQGhSR#";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         // WHEN
         authServer.issueAccessToken(req);
@@ -322,40 +329,46 @@ public class AuthorizationServerTest {
         verify(authServer).findAuthCode(any(TokenRequest.class));
     }
 
-    @Test
-    public void when_issue_token_extract_client_id() throws Exception {
-        // GIVEN
-        HttpRequest req = mock(HttpRequest.class);
-        String content = "redirect_uri=example.com"
-                + "&grant_type=authorization_code&code=eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpq"
-                + "NWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vAmJwoOh_ooe#ovaJVCOiZls_DzvkhOnRVrlDRSzZrbZIB_rwGXjpoeXdJlIjZQGhSR#";
-        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
-        given(req.getContent()).willReturn(buf);
-        willReturn("203598599234220").given(authServer).getBasicAuthorizationClientId(req);
-
-        // WHEN
-        try {
-            authServer.issueAccessToken(req);
-        } catch (OAuthException e) {
-            // nothing to do
-        }
-
-        // THEN
-        verify(authServer).getBasicAuthorizationClientId(req);
-    }
+//    @Test
+//    public void when_issue_token_extract_client_id() throws Exception {
+//        // GIVEN
+//        String clientId = "203598599234220";
+//        String clientSecret = "105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838";
+//        HttpRequest req = mock(HttpRequest.class);
+//        // 203598599234220:105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838
+//        String basicHeader = "Basic MjAzNTk4NTk5MjM0MjIwOjEwNWVmOTNlN2JiMzg2ZGEzYTIzYzMyZTg1NjM0MzRmYWQwMDVmZDBhNmE4ODMxNWZjZGY5NDZhYTc2MWM4Mzg=";
+//        HttpHeaders headers = new DefaultHttpHeaders();
+//        headers.set(HttpHeaders.Names.AUTHORIZATION, basicHeader);
+//        willReturn(headers).given(req).headers();
+//        String content = "redirect_uri=example.com"
+//                + "&grant_type=authorization_code&code=eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpq"
+//                + "NWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vAmJwoOh_ooe#ovaJVCOiZls_DzvkhOnRVrlDRSzZrbZIB_rwGXjpoeXdJlIjZQGhSR#";
+//        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
+//        given(req.getContent()).willReturn(buf);
+//        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
+//
+//        // WHEN
+//        try {
+//            authServer.issueAccessToken(req);
+//        } catch (OAuthException e) {
+//            // nothing to do
+//        }
+//
+//        // THEN
+//        verify(authServer, times(0)).getBasicAuthorizationClientCredentials(req);
+//    }
 
     @Test
     public void when_auth_code_not_valid_return_error() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
-
         HttpRequest req = mock(HttpRequest.class);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+
         String content = "redirect_uri=example.com"
                 + "&grant_type=authorization_code&code=not_valid_code";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         // WHEN
         String errorMsg = null;
@@ -372,7 +385,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_auth_code_for_another_redirect_uri_return_token() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         String redirectUri1 = "example1.com";
         String redirectUri2 = "example2.com";
         ClientCredentials client = mock(ClientCredentials.class);
@@ -387,13 +399,14 @@ public class AuthorizationServerTest {
         given(authServer.db.findAuthCode(code, redirectUri2)).willReturn(authCode);
 
         HttpRequest req = mock(HttpRequest.class);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
         String content = "redirect_uri="
                 + redirectUri2
                 + "&grant_type=authorization_code&code=eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpq"
                 + "NWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vAmJwoOh_ooe#ovaJVCOiZls_DzvkhOnRVrlDRSzZrbZIB_rwGXjpoeXdJlIjZQGhSR#";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         // WHEN
         AccessToken token = authServer.issueAccessToken(req);
@@ -601,7 +614,7 @@ public class AuthorizationServerTest {
         willReturn(headers).given(req).headers();
 
         // WHEN
-        authServer.getBasicAuthorizationClientId(req);
+        AuthorizationServer.getBasicAuthorizationClientCredentials(req);
 
         // THEN
         verify(req.headers()).get(HttpHeaders.Names.AUTHORIZATION);
@@ -616,10 +629,11 @@ public class AuthorizationServerTest {
         willReturn(headers).given(req).headers();
 
         // WHEN
-        String clientId = authServer.getBasicAuthorizationClientId(req);
+        String [] clientCreds = AuthorizationServer.getBasicAuthorizationClientCredentials(req);
 
         // THEN
-        assertNull(clientId);
+        assertNull(clientCreds[0]);
+        assertNull(clientCreds[1]);
     }
 
     @Test
@@ -639,10 +653,11 @@ public class AuthorizationServerTest {
         willReturn(true).given(authServer.db).validClient(clientId, clientSecret);
 
         // WHEN
-        String result = authServer.getBasicAuthorizationClientId(req);
+        String [] result = AuthorizationServer.getBasicAuthorizationClientCredentials(req);
 
         // THEN
-        assertEquals(result, clientId);
+        assertEquals(result [0], clientId);
+        assertEquals(result [1], clientSecret);
     }
 
     @Test
@@ -652,7 +667,7 @@ public class AuthorizationServerTest {
         String content = "grant_type=password&username=user&password=pass";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         willReturn(buf).given(req).getContent();
-        willReturn(null).given(authServer).getBasicAuthorizationClientId(req);
+        willReturn(new DefaultHttpHeaders()).given(req).headers();
 
         // WHEN
         String errorMsg = null;
@@ -663,14 +678,13 @@ public class AuthorizationServerTest {
         }
 
         // THEN
-        assertEquals(errorMsg, Response.INVALID_CLIENT_ID);
+        assertEquals(errorMsg, String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.CLIENT_ID));
     }
 
     @Test
     public void when_issue_token_and_redirect_id_not_the_same_as_auth_code_return_error()
             throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         String redirectUri = "example.com";
         String redirectUri2 = "example.com2222";
         ClientCredentials client = mock(ClientCredentials.class);
@@ -685,13 +699,14 @@ public class AuthorizationServerTest {
         given(authServer.db.findAuthCode(authCode, redirectUri2)).willReturn(loadedCode);
 
         HttpRequest req = mock(HttpRequest.class);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
         String content = "redirect_uri="
                 + redirectUri2
                 + "&grant_type=authorization_code&code=eWPoZNvLxVDxuoVBCnGurPXefa#ttxKfryNbLPDvPFsFSkXVhreWW=HvULXWANTnhR=UEtkiaCxsOxgv_nTpq"
                 + "NWQFB-zGkQBHVoqQkjiWkyRuAHZWkFfn#sNeBhJVgOsR=F_vAmJwoOh_ooe#ovaJVCOiZls_DzvkhOnRVrlDRSzZrbZIB_rwGXjpoeXdJlIjZQGhSR#";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         // WHEN
         String errorMsg = null;
@@ -715,9 +730,8 @@ public class AuthorizationServerTest {
         String content = "grant_type=" + TokenRequest.REFRESH_TOKEN + "&refresh_token=" + refreshToken;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         AccessToken accessToken = mock(AccessToken.class);
         willReturn("02d31ca13a0e448802b063ca2e16010b74b0e96ce9e05e953e").given(accessToken).getToken();
         willReturn(refreshToken).given(accessToken).getRefreshToken();
@@ -738,18 +752,17 @@ public class AuthorizationServerTest {
             throws Exception {
         // GIVEN
         HttpRequest req = mock(HttpRequest.class);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
         String content = "grant_type=" + TokenRequest.CLIENT_CREDENTIALS + "&scope=basic";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        String clientId = "203598599234220";
         ClientCredentials clientCredentials = new ClientCredentials();
         clientCredentials.setScope("basic");
         clientCredentials.setId(clientId);
         given(authServer.db.findClientCredentials(clientId)).willReturn(clientCredentials);
         willReturn("basic").given(authServer.scopeService).getValidScopeByScope(anyString(), anyString());
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
         willDoNothing().given(authServer.db).storeAccessToken(any(AccessToken.class));
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         // WHEN
         AccessToken result = authServer.issueAccessToken(req);
@@ -765,9 +778,8 @@ public class AuthorizationServerTest {
         String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi&password=test";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();;
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         willDoNothing().given(authServer.db).storeAccessToken(any(AccessToken.class));
         UserDetails userDetails = new UserDetails("123456", null);
         willReturn(userDetails).given(authServer).authenticateUser("rossi", "test", req);
@@ -787,11 +799,10 @@ public class AuthorizationServerTest {
         String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi&password=test";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
         willReturn(null).given(authServer).authenticateUser("rossi", "test", req);
         willReturn("basic").given(authServer.scopeService).getValidScope(null, clientId);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         // WHEN
         String errorMsg = null;
@@ -812,9 +823,8 @@ public class AuthorizationServerTest {
         String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi&password=test";
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         UserDetails userDetails = new UserDetails("3232232122", null);
         willReturn(userDetails).given(authServer).authenticateUser("rossi", "test", req);
         willReturn("basic").given(authServer.scopeService).getValidScope(null, clientId);
@@ -861,8 +871,8 @@ public class AuthorizationServerTest {
         clientCredentials.setScope("basic");
         clientCredentials.setId(clientId);
         given(authServer.db.findClientCredentials(clientId)).willReturn(clientCredentials);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         willReturn("basic").given(authServer.scopeService).getValidScopeByScope(null, "basic");
         willReturn(1800).given(authServer.scopeService).getExpiresIn(TokenRequest.CLIENT_CREDENTIALS, "basic");
 
@@ -884,8 +894,8 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         AccessToken accessToken = mock(AccessToken.class);
         willReturn("basic").given(accessToken).getScope();
         willReturn("02d31ca13a0e448802b063ca2e16010b74b0e96ce9e05e953e").given(accessToken).getToken();
@@ -963,7 +973,7 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         willReturn(buf).given(req).getContent();
         willReturn(true).given(authServer).isExistingClient(clientId);
-        //willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
+        //willReturn(getAuthorizationBasicHeader()).given(req).headers();
 
         willReturn(null).given(authServer.db).findAccessToken(accessToken);
 
@@ -987,7 +997,7 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         willReturn(buf).given(req).getContent();
         willReturn(true).given(authServer).isExistingClient(clientId);
-        //willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
+        //willReturn(getAuthorizationBasicHeader()).given(req).headers();
 
         AccessToken dbAccessToken = mock(AccessToken.class);
         willReturn(true).given(dbAccessToken).tokenExpired();
@@ -1146,8 +1156,8 @@ public class AuthorizationServerTest {
         clientCredentials.setScope("basic");
         clientCredentials.setId(clientId);
         given(authServer.db.findClientCredentials(clientId)).willReturn(clientCredentials);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         willReturn("basic").given(authServer.scopeService).getValidScopeByScope(null, "basic");
 
         // WHEN
@@ -1169,8 +1179,8 @@ public class AuthorizationServerTest {
         clientCredentials.setScope("basic");
         clientCredentials.setId(clientId);
         given(authServer.db.findClientCredentials(clientId)).willReturn(clientCredentials);
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         willReturn(null).given(authServer.scopeService).getValidScopeByScope("ext", clientId);
 
         // WHEN
@@ -1192,8 +1202,8 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         willReturn("basic").given(authServer.scopeService).getValidScope(null, clientId);
         UserDetails userDetails = new UserDetails("23433366", null);
         willReturn(userDetails).given(authServer).authenticateUser(anyString(), anyString(), any(HttpRequest.class));
@@ -1214,8 +1224,8 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         willReturn(null).given(authServer.scopeService).getValidScope("ext", clientId);
 
         // WHEN
@@ -1240,8 +1250,8 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         AccessToken accessToken = mock(AccessToken.class);
         willReturn("02d31ca13a0e448802b063ca2e16010b74b0e96ce9e05e953e").given(accessToken).getToken();
         willReturn("basic").given(accessToken).getScope();
@@ -1267,8 +1277,8 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         AccessToken accessToken = mock(AccessToken.class);
         willReturn("02d31ca13a0e448802b063ca2e16010b74b0e96ce9e05e953e").given(accessToken).getToken();
         willReturn("basic, extended").given(accessToken).getScope();
@@ -1295,8 +1305,8 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         AccessToken accessToken = mock(AccessToken.class);
         willReturn("02d31ca13a0e448802b063ca2e16010b74b0e96ce9e05e953e").given(accessToken).getToken();
         willReturn("basic, extended").given(accessToken).getScope();
@@ -1444,7 +1454,6 @@ public class AuthorizationServerTest {
     public void when_client_secret_NOT_passed_and_NO_Basic_Auth_throw_exception() throws Exception {
         // GIVEN
         HttpRequest req = mock(HttpRequest.class);
-        String clientId = "203598599234220";
         String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi&password=test&client_id=" + clientId;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
@@ -1458,7 +1467,7 @@ public class AuthorizationServerTest {
         }
 
         // THEN
-        assertEquals(errorMsg, Response.INVALID_CLIENT_CREDENTIALS);
+        assertEquals(errorMsg, String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.CLIENT_SECRET));
     }
 
     @Test
@@ -1559,7 +1568,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_update_client_app_with_invalid_client_id_throws_oauth_exception_with_bad_request_status() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, HttpRequestHandler.APPLICATION_URI + "/" + clientId);
         req.headers().add(HttpHeaders.Names.CONTENT_TYPE, "application/json");
         String content = "any content here";
@@ -1636,7 +1644,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_client_id_exists_return_true() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         willReturn(mock(ClientCredentials.class)).given(authServer.db).findClientCredentials(clientId);
 
         // WHEN
@@ -1649,7 +1656,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_client_id_does_not_exist_return_false() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         willReturn(null).given(authServer.db).findClientCredentials(clientId);
 
         // WHEN
@@ -1662,7 +1668,6 @@ public class AuthorizationServerTest {
     @Test
     public void when_update_client_app_check_client_id_exists() throws Exception {
         // GIVEN
-        String clientId = "203598599234220";
         HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT,
                 HttpRequestHandler.APPLICATION_URI + "/" + clientId);
         req.headers().add(HttpHeaders.Names.CONTENT_TYPE, "application/json");
@@ -1712,9 +1717,8 @@ public class AuthorizationServerTest {
         String content = "grant_type=" + TokenRequest.REFRESH_TOKEN + "&refresh_token=" + refreshToken;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
-        String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
         AccessToken accessToken = mock(AccessToken.class);
         willReturn("basic").given(accessToken).getScope();
         willReturn("02d31ca13a0e448802b063ca2e16010b74b0e96ce9e05e953e").given(accessToken).getToken();
@@ -1740,9 +1744,8 @@ public class AuthorizationServerTest {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
 
-        String clientId = "203598599234220";
-        willReturn(clientId).given(authServer).getBasicAuthorizationClientId(req);
-        willReturn(true).given(authServer).isActiveClientId(clientId);
+        willReturn(getAuthorizationBasicHeader()).given(req).headers();
+        willReturn(true).given(authServer).isActiveClient(clientId, clientSecret);
 
         AccessToken accessToken = mock(AccessToken.class);
         willReturn("basic").given(accessToken).getScope();
@@ -1761,5 +1764,13 @@ public class AuthorizationServerTest {
 
         // THEN
         verify(authServer.db).removeAccessToken(accessToken.getToken());
+    }
+
+    private HttpHeaders getAuthorizationBasicHeader() {
+        // clientId:clientSecret, 203598599234220:105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838
+        String basicHeader = "Basic MjAzNTk4NTk5MjM0MjIwOjEwNWVmOTNlN2JiMzg2ZGEzYTIzYzMyZTg1NjM0MzRmYWQwMDVmZDBhNmE4ODMxNWZjZGY5NDZhYTc2MWM4Mzg=";
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set(HttpHeaders.Names.AUTHORIZATION, basicHeader);
+        return headers;
     }
 }

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/DBManagerFactoryTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/DBManagerFactoryTest.java
@@ -30,6 +30,7 @@ public class DBManagerFactoryTest {
     @Test
     public void when_mongo_oauth20_database_set_return_mongodb_manager() throws Exception {
         // GIVEN
+        MockDBManagerFactory.deinstall();
         OAuthServer.log = mock(Logger.class);
         String path = getClass().getClassLoader().getResource("apifest-oauth-test.properties").getPath();
         System.setProperty("properties.file", path);

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/MockDBManagerFactory.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/MockDBManagerFactory.java
@@ -27,4 +27,7 @@ public class MockDBManagerFactory extends DBManagerFactory {
         DBManagerFactory.dbManager = mock(DBManager.class);
     }
 
+    public static void deinstall() {
+        DBManagerFactory.dbManager = null;
+    }
 }

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/MongoDBManagerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/MongoDBManagerTest.java
@@ -46,6 +46,11 @@ public class MongoDBManagerTest {
 
     @BeforeMethod
     public void setup() {
+        OAuthServer.log = mock(Logger.class);
+        String path = getClass().getClassLoader().getResource("apifest-oauth-test.properties").getPath();
+        System.setProperty("properties.file", path);
+        OAuthServer.loadConfig();
+
         dbManager = spy(new MongoDBManager());
         MongoDBManager.log = mock(Logger.class);
         db = mock(DB.class);

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/TokenRequestTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/TokenRequestTest.java
@@ -35,6 +35,9 @@ public class TokenRequestTest {
 
     HttpRequest req;
 
+    String clientId = "203598599234220";
+    String clientSecret = "105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838";
+
     @BeforeMethod
     public void setup() {
         req = mock(HttpRequest.class);
@@ -44,11 +47,10 @@ public class TokenRequestTest {
     @Test
     public void when_grant_type_is_missing_throws_exception() throws Exception {
         // GIVEN
-        String content = "redirect_uri=example.com" + "&code=not_valid_code";
+        String content = "redirect_uri=example.com" + "&code=not_valid_code" + "&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         String errorMsg = null;
@@ -59,19 +61,17 @@ public class TokenRequestTest {
         }
 
         // THEN
-        assertEquals(errorMsg,
-                String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.GRANT_TYPE));
+        assertEquals(errorMsg, String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.GRANT_TYPE));
     }
 
     @Test
     public void when_grant_type_not_supported_throws_exception() throws Exception {
         // GIVEN
         String content = "redirect_uri=example.com"
-                + "&grant_type=not_supported&code=not_valid_code";
+                + "&grant_type=not_supported&code=not_valid_code" + "&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         String errorMsg = null;
@@ -89,11 +89,10 @@ public class TokenRequestTest {
     public void when_auth_code_is_missing_throws_exception() throws Exception {
         // GIVEN
         String content = "grant_type=" + TokenRequest.AUTHORIZATION_CODE
-                + "&redirect_uri=example.com";
+                + "&redirect_uri=example.com" + "&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         String errorMsg = null;
@@ -110,13 +109,12 @@ public class TokenRequestTest {
     @Test
     public void when_redirect_uri_is_missing_throws_exception() throws Exception {
         // GIVEN
-        // "client_id=203598599234220&"
-        String content = "grant_type=" + TokenRequest.AUTHORIZATION_CODE + "&code=valid_code";
+        String content = "grant_type=" + TokenRequest.AUTHORIZATION_CODE + "&code=valid_code&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
 
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
+
 
         // WHEN
         String errorMsg = null;
@@ -127,15 +125,14 @@ public class TokenRequestTest {
         }
 
         // THEN
-        assertEquals(errorMsg,
-                String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.REDIRECT_URI));
+        assertEquals(errorMsg, String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.REDIRECT_URI));
     }
 
     @Test
     public void when_client_id_is_missing_throws_exception() throws Exception {
         // GIVEN
         String content = "grant_type=" + TokenRequest.AUTHORIZATION_CODE
-                + "code=valid_code&redirect_uri=example.com";
+                + "&code=valid_code&redirect_uri=example.com" + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
@@ -149,19 +146,17 @@ public class TokenRequestTest {
         }
 
         // THEN
-        assertEquals(errorMsg,
-                String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.CLIENT_ID));
+        assertEquals(errorMsg, String.format(Response.MANDATORY_PARAM_MISSING, TokenRequest.CLIENT_ID));
     }
 
     @Test
     public void when_all_mandatory_params_present_do_not_throw_exception() throws Exception {
         // GIVEN
         String content = "grant_type=" + TokenRequest.AUTHORIZATION_CODE
-                + "&code=valid_code&redirect_uri=example.com";
+                + "&code=valid_code&redirect_uri=example.com&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         tokenReq.validate();
@@ -170,11 +165,10 @@ public class TokenRequestTest {
     @Test
     public void when_grant_type_refresh_token_and_no_refresh_token_return_error() throws Exception {
         // GIVEN
-        String content = "grant_type=" + TokenRequest.REFRESH_TOKEN;
+        String content = "grant_type=" + TokenRequest.REFRESH_TOKEN + "&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         String errorMsg = null;
@@ -192,11 +186,10 @@ public class TokenRequestTest {
     @Test
     public void when_grant_type_password_and_no_username_return_error() throws Exception {
         // GIVEN
-        String content = "grant_type=" + TokenRequest.PASSWORD + "&password=pd1&wyfr";
+        String content = "grant_type=" + TokenRequest.PASSWORD + "&password=pd1&wyfr&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         String errorMsg = null;
@@ -214,11 +207,10 @@ public class TokenRequestTest {
     @Test
     public void when_grant_type_password_and_no_password_return_error() throws Exception {
         // GIVEN
-        String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi";
+        String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         String errorMsg = null;
@@ -236,11 +228,11 @@ public class TokenRequestTest {
     @Test
     public void when_clientId_empty_check_mandatory_params_throws_exception() throws Exception {
         // GIVEN
-        String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi";
+        String clientId = "";
+        String content = "grant_type=" + TokenRequest.PASSWORD + "&username=rossi&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("");
 
         // WHEN
         String errorMsg = null;
@@ -257,11 +249,10 @@ public class TokenRequestTest {
     @Test
     public void when_grantType_empty_check_mandatory_params_throws_exception() throws Exception {
         // GIVEN
-        String content = "grant_type=" + "" +"&username=rossi";
+        String content = "grant_type=" + "" +"&username=rossi&client_id=" + clientId + "&client_secret=" + clientSecret;
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
         given(req.getContent()).willReturn(buf);
         TokenRequest tokenReq = new TokenRequest(req);
-        tokenReq.setClientId("203598599234220");
 
         // WHEN
         String errorMsg = null;


### PR DESCRIPTION
When client_id or client_secret is missing on POST /oauth20/tokens, return "mandatory parameter client_id/client_secret is missing"