### PR TITLE
Upgrade Hazelcast version to 3.4.2. Fix an issue into HC implementation of updateAccessTokenValidStatus()

### DIFF
--- a/apifest-oauth20/pom.xml
+++ b/apifest-oauth20/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.apifest</groupId>
   <artifactId>apifest-oauth20</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.1.4-SNAPSHOT</version>
   <name>ApiFest-OAuth20</name>
 
   <properties>
@@ -88,12 +88,12 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-client</artifactId>
-      <version>3.2.3</version>
+      <version>3.4.2</version>
     </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>3.2.3</version>
+      <version>3.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/persistence/hazelcast/HazelcastDBManager.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/persistence/hazelcast/HazelcastDBManager.java
@@ -36,6 +36,7 @@ import com.apifest.oauth20.DBManager;
 import com.apifest.oauth20.OAuthServer;
 import com.apifest.oauth20.Scope;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.InMemoryFormat;
@@ -43,11 +44,10 @@ import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MaxSizeConfig.MaxSizePolicy;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
-import com.hazelcast.config.MapConfig.EvictionPolicy;
-import com.hazelcast.config.MaxSizeConfig.MaxSizePolicy;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -234,7 +234,7 @@ public class HazelcastDBManager implements DBManager {
     public void updateAccessTokenValidStatus(String accessToken, boolean valid) {
         PersistentAccessToken persistentAccessToken = getAccessTokenContainer().get(accessToken);
         persistentAccessToken.setValid(valid);
-        getAccessTokenContainer().put(accessToken, persistentAccessToken);
+        getAccessTokenContainer().put(accessToken, persistentAccessToken, Long.valueOf(persistentAccessToken.getRefreshExpiresIn()), TimeUnit.SECONDS);
     }
 
     /*

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.apifest</groupId>
   <artifactId>apifest-oauth20-parent</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>apifest-oauth20-parent</name>
 


### PR DESCRIPTION
A token can be stored without TTL by updateAccessTokenValidStatus() if it is already evicted by the HC when the isValidToken is called. HC version 3.2.3 has an issue hazelcast/hazelcast#4144 with explicit TTL entries.