### PR TITLE
[issue #57] Add appropriate messages when JSON is not valid or input validation does not pass

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ApplicationInfo.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ApplicationInfo.java
@@ -41,6 +41,8 @@ public class ApplicationInfo implements Serializable {
 
     protected static Logger log = LoggerFactory.getLogger(ApplicationInfo.class);
 
+    public static final String JSON_STATUS = "status";
+
     private static final long serialVersionUID = 6017283924235608024L;
 
     @JsonProperty("redirect_uri")

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ApplicationInfoValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ApplicationInfoValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Validates input for client application services.
+ *
+ * @author Rossitsa Borissova
+ *
+ */
+public class ApplicationInfoValidator implements JsonInputValidator {
+
+    protected static ApplicationInfoValidator instance;
+
+    private ApplicationInfoValidator() {
+    }
+
+    public void validate(String name, String value) throws OAuthException {
+        if (ApplicationInfo.JSON_STATUS.equals(name)) {
+            try {
+                Integer.valueOf(value);
+            } catch (NumberFormatException e) {
+                throw new OAuthException(String.format(Response.ERROR_NOT_INTEGER, ApplicationInfo.JSON_STATUS), HttpResponseStatus.BAD_REQUEST);
+            }
+        }
+    }
+
+    public static ApplicationInfoValidator getInstance() {
+        if (instance == null) {
+            instance = new ApplicationInfoValidator();
+        }
+        return instance;
+    }
+
+}

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ApplicationInfoValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ApplicationInfoValidator.java
@@ -25,8 +25,6 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
  */
 public class ApplicationInfoValidator implements JsonInputValidator {
 
-    protected static ApplicationInfoValidator instance;
-
     private ApplicationInfoValidator() {
     }
 
@@ -41,10 +39,15 @@ public class ApplicationInfoValidator implements JsonInputValidator {
     }
 
     public static ApplicationInfoValidator getInstance() {
-        if (instance == null) {
-            instance = new ApplicationInfoValidator();
-        }
-        return instance;
+       return Holder.validator;
     }
 
+    protected static class Holder {
+        public static ApplicationInfoValidator validator = new ApplicationInfoValidator();
+
+        // used for unit tests only!
+        protected static void recreateInstance() {
+            validator = new ApplicationInfoValidator();
+        }
+    }
 }

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -430,10 +429,8 @@ public class AuthorizationServer {
             if (!isExistingClient(clientId)) {
                 throw new OAuthException(Response.INVALID_CLIENT_ID, HttpResponseStatus.BAD_REQUEST);
             }
-            //ObjectMapper mapper = new ObjectMapper();
             ApplicationInfo appInfo;
             try {
-                //appInfo = mapper.readValue(content, ApplicationInfo.class);
                 appInfo = InputValidator.validate(content, ApplicationInfo.class);
                 if (appInfo.validForUpdate()) {
                     if (appInfo.getScope() != null) {

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/HttpRequestHandler.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/HttpRequestHandler.java
@@ -419,6 +419,7 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
                     response = Response.createOkResponse(Response.CLIENT_APP_UPDATED);
                 }
             } catch (OAuthException ex) {
+                log.info("ex: " + ex.getMessage());
                 response = Response.createOAuthExceptionResponse(ex);
                 invokeExceptionHandler(ex, req);
             }

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/HttpRequestHandler.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/HttpRequestHandler.java
@@ -419,7 +419,6 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
                     response = Response.createOkResponse(Response.CLIENT_APP_UPDATED);
                 }
             } catch (OAuthException ex) {
-                log.info("ex: " + ex.getMessage());
                 response = Response.createOAuthExceptionResponse(ex);
                 invokeExceptionHandler(ex, req);
             }

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/InputValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/InputValidator.java
@@ -51,7 +51,9 @@ public class InputValidator {
                 String str = delegate.getText();
                 try {
                     JsonInputValidator validator = JsonInputValidatorFactory.getValidator(clazz);
-                    validator.validate(delegate.getCurrentName(), str);
+                    if (validator != null) {
+                        validator.validate(delegate.getCurrentName(), str);
+                    }
                 } catch (OAuthException e) {
                     throw new JsonValidationException(e.getMessage());
                 }

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/InputValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/InputValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import java.io.IOException;
+
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.util.JsonParserDelegate;
+
+/**
+ * Validates a given input.
+ *
+ * @author Rossitsa Borissova
+ *
+ */
+public class InputValidator {
+
+    /**
+     * Validates an input and returns an instance of a given class constructed from the input.
+     * @param input the input to be validated
+     * @param clazz the class to be used to create an instance from the input
+     * @return an instance created from the input
+     * @throws JsonParseException
+     * @throws IOException
+     */
+    public static <T> T validate(String input, final Class<T> clazz) throws JsonParseException, IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonFactory factory = mapper.getJsonFactory();
+        JsonParser parser = null;
+        T obj = null;
+        parser = factory.createJsonParser(input);
+        JsonParser parserWrapper = new JsonParserDelegate(parser) {
+
+            public String getText() throws IOException, JsonParseException {
+                String str = delegate.getText();
+                try {
+                    JsonInputValidator validator = JsonInputValidatorFactory.getValidator(clazz);
+                    validator.validate(delegate.getCurrentName(), str);
+                } catch (OAuthException e) {
+                    throw new JsonValidationException(e.getMessage());
+                }
+                return str;
+            }
+        };
+        obj = mapper.readValue(parserWrapper, clazz);
+        return obj;
+    }
+
+}

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/JsonInputValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/JsonInputValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+/**
+ * Validates JSON input.
+ *
+ * @author Rossitsa Borissova
+ *
+ */
+public interface JsonInputValidator {
+
+    public void validate(String name, String value) throws OAuthException;
+}

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/JsonInputValidatorFactory.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/JsonInputValidatorFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+/**
+ * Factory class for different input validators.
+ *
+ * @author Rossitsa Borissova
+ *
+ */
+public class JsonInputValidatorFactory {
+
+    /**
+     * Instantiates a validator depending on the class passed as a parameter.
+     * @param clazz the class the input will be validated to
+     * @return JsonInputValidator
+     */
+    public static JsonInputValidator getValidator(Class<?> clazz) {
+        if (clazz.equals(Scope.class)) {
+            return ScopeValidator.getInstance();
+        }
+        if (clazz.equals(ApplicationInfo.class)) {
+            return ApplicationInfoValidator.getInstance();
+        }
+        return null;
+    }
+}

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/JsonValidationException.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/JsonValidationException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import org.codehaus.jackson.JsonParseException;
+
+/**
+ * Represents a JSON validation exception.
+ *
+ * @author Rossitsa Borissova
+ *
+ */
+public class JsonValidationException extends JsonParseException {
+
+    private static final long serialVersionUID = 4343311202369477896L;
+
+    public JsonValidationException(String message) {
+        super(message, null);
+    }
+}

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/Response.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/Response.java
@@ -55,6 +55,8 @@ public final class Response {
     public static final String SCOPE_NOK_MESSAGE = "{\"status\":\"scope not valid\"}";
     public static final String CLIENT_APP_UPDATED = "{\"status\":\"client application updated\"}";
     public static final String CANNOT_LIST_CLIENT_APPS = "{\"error\":\"cannot list client applications\"}";
+    public static final String INVALID_JSON_ERROR = "{\"error\":\"invalid JSON\"}";
+    public static final String ERROR_NOT_INTEGER = "{\"error\":\"%s is not an integer\"}";
 
     public static final String APPLICATION_JSON = "application/json";
 

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/Scope.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/Scope.java
@@ -37,21 +37,25 @@ public class Scope {
     static final String PASS_EXPIRES_IN_FIELD = "passExpiresIn";
     static final String REFRESH_EXPIRES_IN_FIELD = "refreshExpiresIn";
 
+    static final String JSON_CC_EXPIRES_IN = "cc_expires_in";
+    static final String JSON_PASS_EXPIRES_IN = "pass_expires_in";
+    static final String JSON_REFRESH_EXPIRES_IN = "refresh_expires_in";
+
     static final Pattern SCOPE_PATTERN = Pattern.compile("^(\\p{Alnum}+-?_?)+$");
 
-    @JsonProperty("scope")
+    @JsonProperty(SCOPE_FIELD)
     private String scope;
 
-    @JsonProperty("description")
+    @JsonProperty(DESCRIPTION_FIELD)
     private String description;
 
-    @JsonProperty("cc_expires_in")
+    @JsonProperty(JSON_CC_EXPIRES_IN)
     private Integer ccExpiresIn;
 
-    @JsonProperty("pass_expires_in")
+    @JsonProperty(JSON_PASS_EXPIRES_IN)
     private Integer passExpiresIn;
 
-    @JsonProperty("refresh_expires_in")
+    @JsonProperty(JSON_REFRESH_EXPIRES_IN)
     private Integer refreshExpiresIn;
 
     public String getScope() {

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeService.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeService.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
@@ -34,8 +33,6 @@ import org.jboss.netty.handler.codec.http.QueryStringDecoder;
 import org.jboss.netty.util.CharsetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.gson.JsonParser;
 
 /**
  * Responsible for storing and loading OAuth20 scopes.
@@ -245,9 +242,7 @@ public class ScopeService {
         String responseMsg = "";
         // check Content-Type
         if (contentType != null && contentType.contains(Response.APPLICATION_JSON)) {
-            ObjectMapper mapper = new ObjectMapper();
             try {
-                //Scope scope = mapper.readValue(content, Scope.class);
                 Scope scope = InputValidator.validate(content, Scope.class);
                 if (scope.validForUpdate()) {
                     Scope foundScope = DBManagerFactory.getInstance().findScope(scopeName);

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeValidator.java
@@ -41,9 +41,15 @@ public class ScopeValidator implements JsonInputValidator {
     }
 
     public static ScopeValidator getInstance() {
-        if (instance == null) {
-            instance = new ScopeValidator();
+        return Holder.validator;
+    }
+
+    protected static class Holder {
+        public static ScopeValidator validator = new ScopeValidator();
+
+        // used for unit tests only!
+        protected static void recreateInstance() {
+            validator = new ScopeValidator();
         }
-        return instance;
     }
 }

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Validates an input for scope services.
+ *
+ * @author Rossitsa Borissova
+ *
+ */
+public class ScopeValidator implements JsonInputValidator {
+
+    protected static ScopeValidator instance;
+
+    private ScopeValidator() {
+    }
+
+    public void validate(String name, String value) throws OAuthException {
+        if (Scope.JSON_CC_EXPIRES_IN.equals(name) || Scope.JSON_PASS_EXPIRES_IN.equals(name) || Scope.JSON_REFRESH_EXPIRES_IN.equals(name)) {
+            try {
+                Integer.valueOf(value);
+            } catch (NumberFormatException e) {
+                throw new OAuthException(String.format(Response.ERROR_NOT_INTEGER, name), HttpResponseStatus.BAD_REQUEST);
+            }
+        }
+    }
+
+    public static ScopeValidator getInstance() {
+        if (instance == null) {
+            instance = new ScopeValidator();
+        }
+        return instance;
+    }
+}

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/ApplicationInfoValidatorTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/ApplicationInfoValidatorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.testng.annotations.Test;
+
+/**
+ * @author Rossitsa Borissova
+ *
+ */
+public class ApplicationInfoValidatorTest {
+
+
+    @Test
+    public void when_status_is_not_an_integer_throw_exception() throws Exception {
+        ApplicationInfoValidator validator = ApplicationInfoValidator.getInstance();
+
+        // WHEN
+        String errorMsg = null;
+        HttpResponseStatus status = null;
+        try {
+            validator.validate(ApplicationInfo.JSON_STATUS, "300a");
+        } catch (OAuthException e) {
+            errorMsg = e.getMessage();
+            status = e.getHttpStatus();
+        }
+
+        // THEN
+        assertEquals(errorMsg, String.format(Response.ERROR_NOT_INTEGER, ApplicationInfo.JSON_STATUS));
+        assertEquals(status, HttpResponseStatus.BAD_REQUEST);
+    }
+}

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/ApplicationInfoValidatorTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/ApplicationInfoValidatorTest.java
@@ -15,9 +15,7 @@
  */
 package com.apifest.oauth20;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.testng.annotations.Test;

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/AuthorizationServerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/AuthorizationServerTest.java
@@ -1718,6 +1718,99 @@ public class AuthorizationServerTest {
         verify(authServer.db).removeAccessToken(accessToken.getToken());
     }
 
+
+    @Test
+    public void when_issue_client_credentials_invoke_validator() throws Exception {
+        // GIVEN
+        MockApplicationInfoValidator.install();
+        HttpRequest req = mock(HttpRequest.class);
+        int paramsCount = 3;
+        String content = "{\"name\":\"name\",\"redirect_uri\":\"http://example.com\", \"scope\":\"basic\"}";
+        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
+        willReturn(buf).given(req).getContent();
+        HttpHeaders headers = mock(HttpHeaders.class);
+        willReturn("application/json").given(headers).get(HttpHeaders.Names.CONTENT_TYPE);
+        willReturn(headers).given(req).headers();
+        Scope scope = new Scope();
+        willReturn(scope).given(authServer.db).findScope("basic");
+
+        // WHEN
+        authServer.issueClientCredentials(req);
+
+        // THEN
+        verify(ApplicationInfoValidator.getInstance(), times(paramsCount)).validate(anyString(), anyString());
+
+        MockApplicationInfoValidator.deinstall();
+    }
+
+    @Test
+    public void when_update_client_app_invoke_validator() throws Exception {
+        // GIVEN
+        MockApplicationInfoValidator.install();
+        int paramsCount = 3;
+        String content = "{\"name\":\"name\",\"redirect_uri\":\"http://example.com\", \"scope\":\"basic\"}";
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, HttpRequestHandler.APPLICATION_URI + "/" + clientId);
+        req.headers().add(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+        req.setContent(ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8)));
+        Scope scope = new Scope();
+        willReturn(scope).given(authServer.db).findScope("basic");
+        willReturn(true).given(authServer).isExistingClient(clientId);
+
+        // WHEN
+        authServer.updateClientApp(req, clientId);
+
+        // THEN
+        verify(ApplicationInfoValidator.getInstance(), times(paramsCount)).validate(anyString(), anyString());
+
+        MockApplicationInfoValidator.deinstall();
+    }
+
+    @Test
+    public void when_update_client_app_with_invalid_JSON_throw_OAuth_exception_with_invalid_JSON_error() throws Exception {
+        // GIVEN
+        String content = "{\"name\":\"name\",\"redirect_uri\":\"http://example.com\", \"scope\":\"basic\"";
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, HttpRequestHandler.APPLICATION_URI + "/" + clientId);
+        req.headers().add(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+        req.setContent(ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8)));
+        Scope scope = new Scope();
+        willReturn(scope).given(authServer.db).findScope("basic");
+        willReturn(true).given(authServer).isExistingClient(clientId);
+
+        // WHEN
+        String errorMsg = null;
+        try {
+            authServer.updateClientApp(req, clientId);
+        } catch (OAuthException e) {
+            errorMsg = e.getMessage();
+        }
+
+        // THEN
+        assertEquals(errorMsg, Response.INVALID_JSON_ERROR);
+    }
+
+    @Test
+    public void when_update_client_app_with_invalid_status_value_throw_OAuth_exception_with_error() throws Exception {
+        // GIVEN
+        String content = "{\"status\":\"1a\"}";
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, HttpRequestHandler.APPLICATION_URI + "/" + clientId);
+        req.headers().add(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+        req.setContent(ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8)));
+        Scope scope = new Scope();
+        willReturn(scope).given(authServer.db).findScope("basic");
+        willReturn(true).given(authServer).isExistingClient(clientId);
+
+        // WHEN
+        String errorMsg = null;
+        try {
+            authServer.updateClientApp(req, clientId);
+        } catch (OAuthException e) {
+            errorMsg = e.getMessage();
+        }
+
+        // THEN
+        assertEquals(errorMsg, String.format(Response.ERROR_NOT_INTEGER, ApplicationInfo.JSON_STATUS));
+    }
+
     private HttpHeaders getAuthorizationBasicHeader() {
         // clientId:clientSecret, 203598599234220:105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838
         String basicHeader = "Basic MjAzNTk4NTk5MjM0MjIwOjEwNWVmOTNlN2JiMzg2ZGEzYTIzYzMyZTg1NjM0MzRmYWQwMDVmZDBhNmE4ODMxNWZjZGY5NDZhYTc2MWM4Mzg=";

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/ClientCredentialsTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/ClientCredentialsTest.java
@@ -16,9 +16,10 @@
 
 package com.apifest.oauth20;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/HttpRequestHandlerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/HttpRequestHandlerTest.java
@@ -20,12 +20,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.jboss.netty.channel.Channel;

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
@@ -15,10 +15,9 @@
  */
 package com.apifest.oauth20;
 
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
 
 import org.testng.annotations.Test;
 
@@ -59,5 +58,12 @@ public class InputValidatorTest {
         // THEN
         verify(ApplicationInfoValidator.instance).validate(ApplicationInfo.JSON_STATUS, inputValue);
         MockApplicationInfoValidator.deinstall();
+    }
+
+    @Test
+    public void when_no_validator_do_not_throw_NPE() throws Exception {
+
+        // WHEN
+        InputValidator.validate("{\"client_id\":\"123456\"}", ClientCredentials.class);
     }
 }

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
@@ -40,7 +40,7 @@ public class InputValidatorTest {
         InputValidator.validate("{\"" + Scope.JSON_CC_EXPIRES_IN + "\":\"" + inputValue + "\"}", Scope.class);
 
         // THEN
-        verify(ScopeValidator.instance).validate(Scope.JSON_CC_EXPIRES_IN, inputValue);
+        verify(ScopeValidator.getInstance()).validate(Scope.JSON_CC_EXPIRES_IN, inputValue);
         MockScopeValidator.deinstall();
     }
 
@@ -56,7 +56,7 @@ public class InputValidatorTest {
         InputValidator.validate("{\"" + ApplicationInfo.JSON_STATUS + "\":\"" + inputValue + "\"}", ApplicationInfo.class);
 
         // THEN
-        verify(ApplicationInfoValidator.instance).validate(ApplicationInfo.JSON_STATUS, inputValue);
+        verify(ApplicationInfoValidator.getInstance()).validate(ApplicationInfo.JSON_STATUS, inputValue);
         MockApplicationInfoValidator.deinstall();
     }
 

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Rossitsa Borissova
+ *
+ */
+public class InputValidatorTest {
+
+
+    @Test
+    public void when_scope_input_invoke_validate_method_of_scope_validator_class() throws Exception {
+        // GIVEN
+        MockScopeValidator.install();
+        willDoNothing().given(JsonInputValidatorFactory.getValidator(Scope.class)).validate(anyString(), anyString());
+
+        String inputValue = "300";
+
+        // WHEN
+        InputValidator.validate("{\"" + Scope.JSON_CC_EXPIRES_IN + "\":\"" + inputValue + "\"}", Scope.class);
+
+        // THEN
+        verify(ScopeValidator.instance).validate(Scope.JSON_CC_EXPIRES_IN, inputValue);
+        MockScopeValidator.deinstall();
+    }
+
+    @Test
+    public void when_application_info_input_invoke_validate_method_of_application_info_validator_class() throws Exception {
+        // GIVEN
+        MockApplicationInfoValidator.install();
+        willDoNothing().given(JsonInputValidatorFactory.getValidator(ApplicationInfo.class)).validate(anyString(), anyString());
+
+        String inputValue = "1";
+
+        // WHEN
+        InputValidator.validate("{\"" + ApplicationInfo.JSON_STATUS + "\":\"" + inputValue + "\"}", ApplicationInfo.class);
+
+        // THEN
+        verify(ApplicationInfoValidator.instance).validate(ApplicationInfo.JSON_STATUS, inputValue);
+        MockApplicationInfoValidator.deinstall();
+    }
+}

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/JsonInputValidatorFactoryTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/JsonInputValidatorFactoryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Rossitsa Borissova
+ *
+ */
+public class JsonInputValidatorFactoryTest {
+
+    @Test
+    public void when_scope_class_return_scope_validator() throws Exception {
+        // WHEN
+        JsonInputValidator validator = JsonInputValidatorFactory.getValidator(Scope.class);
+
+        // THEN
+        assertTrue(validator instanceof ScopeValidator);
+    }
+
+    @Test
+    public void when_application_info_class_return_application_info_validator() throws Exception {
+        // WHEN
+        JsonInputValidator validator = JsonInputValidatorFactory.getValidator(ApplicationInfo.class);
+
+        // THEN
+        assertTrue(validator instanceof ApplicationInfoValidator);
+    }
+}

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/MockApplicationInfoValidator.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/MockApplicationInfoValidator.java
@@ -24,11 +24,11 @@ import static org.mockito.Mockito.mock;
 public class MockApplicationInfoValidator {
 
     public static void install() {
-        ApplicationInfoValidator.instance = mock(ApplicationInfoValidator.class);
+        ApplicationInfoValidator.Holder.validator = mock(ApplicationInfoValidator.class);
     }
 
 
     public static void deinstall() {
-        ApplicationInfoValidator.instance = null;
+        ApplicationInfoValidator.Holder.recreateInstance();
     }
 }

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/MockApplicationInfoValidator.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/MockApplicationInfoValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Rossitsa Borissova
+ *
+ */
+public class MockApplicationInfoValidator {
+
+    public static void install() {
+        ApplicationInfoValidator.instance = mock(ApplicationInfoValidator.class);
+    }
+
+
+    public static void deinstall() {
+        ApplicationInfoValidator.instance = null;
+    }
+}

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/MockScopeValidator.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/MockScopeValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Rossitsa Borissova
+ *
+ */
+public class MockScopeValidator {
+
+    public static void install() {
+        ScopeValidator.instance = mock(ScopeValidator.class);
+    }
+
+    public static void deinstall() {
+        ScopeValidator.instance = null;
+    }
+}

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/MockScopeValidator.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/MockScopeValidator.java
@@ -24,10 +24,10 @@ import static org.mockito.Mockito.mock;
 public class MockScopeValidator {
 
     public static void install() {
-        ScopeValidator.instance = mock(ScopeValidator.class);
+        ScopeValidator.Holder.validator = mock(ScopeValidator.class);
     }
 
     public static void deinstall() {
-        ScopeValidator.instance = null;
+        ScopeValidator.Holder.recreateInstance();
     }
 }

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/ScopeServiceTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/ScopeServiceTest.java
@@ -16,10 +16,18 @@
 
 package com.apifest.oauth20;
 
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/ScopeValidatorTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/ScopeValidatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apifest.oauth20;
+
+import static org.testng.Assert.assertEquals;
+
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.testng.annotations.Test;
+
+/**
+ * @author Rossitsa Borissova
+ *
+ */
+public class ScopeValidatorTest {
+
+
+    @Test
+    public void when_cc_expires_in_is_not_integer_throw_exception() throws Exception {
+        // GIVEN
+        ScopeValidator validator = ScopeValidator.getInstance();
+
+        // WHEN
+        String errorMsg = null;
+        HttpResponseStatus status = null;
+        try {
+            validator.validate(Scope.JSON_CC_EXPIRES_IN, "300a");
+        } catch (OAuthException e) {
+            errorMsg = e.getMessage();
+            status = e.getHttpStatus();
+        }
+
+        // THEN
+        assertEquals(errorMsg, String.format(Response.ERROR_NOT_INTEGER, Scope.JSON_CC_EXPIRES_IN));
+        assertEquals(status, HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void when_pass_expires_in_is_not_integer_throw_exception() throws Exception {
+        // GIVEN
+        ScopeValidator validator = ScopeValidator.getInstance();
+
+        // WHEN
+        String errorMsg = null;
+        HttpResponseStatus status = null;
+        try {
+            validator.validate(Scope.JSON_PASS_EXPIRES_IN, "300a");
+        } catch (OAuthException e) {
+            errorMsg = e.getMessage();
+            status = e.getHttpStatus();
+        }
+
+        // THEN
+        assertEquals(errorMsg, String.format(Response.ERROR_NOT_INTEGER, Scope.JSON_PASS_EXPIRES_IN));
+        assertEquals(status, HttpResponseStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void when_refresh_expires_in_is_not_integer_throw_exception() throws Exception {
+        // GIVEN
+        ScopeValidator validator = ScopeValidator.getInstance();
+
+        // WHEN
+        String errorMsg = null;
+        HttpResponseStatus status = null;
+        try {
+            validator.validate(Scope.JSON_REFRESH_EXPIRES_IN, "300a");
+        } catch (OAuthException e) {
+            errorMsg = e.getMessage();
+            status = e.getHttpStatus();
+        }
+
+        // THEN
+        assertEquals(errorMsg, String.format(Response.ERROR_NOT_INTEGER, Scope.JSON_REFRESH_EXPIRES_IN));
+        assertEquals(status, HttpResponseStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
When JSON is not vali return {"error":"invalid JSON"}.
When a field must be an integer, return {"error":"%s is not an integer"}.
The validation for integer should be applied to the following parameters: 
    status in /oauth20/applications and cc_expires_in, pass_expires_in and refresh_expires_in in /oauth20/scopes.

