### PR TITLE
[Issue #59] Add Content-Length header even if the response is empty

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/Response.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/Response.java
@@ -88,9 +88,11 @@ public final class Response {
         if (message != null) {
             ChannelBuffer buf = ChannelBuffers.copiedBuffer(message.getBytes(CharsetUtil.UTF_8));
             response.setContent(buf);
-            response.headers().set(HttpHeaders.Names.CONTENT_TYPE, APPLICATION_JSON);
             response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, buf.array().length);
+        } else {
+            response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, 0);
         }
+        response.headers().set(HttpHeaders.Names.CONTENT_TYPE, APPLICATION_JSON);
         response.headers().set(HttpHeaders.Names.CACHE_CONTROL, HttpHeaders.Values.NO_STORE);
         response.headers().set(HttpHeaders.Names.PRAGMA, HttpHeaders.Values.NO_CACHE);
         return response;

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/ResponseTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/ResponseTest.java
@@ -149,4 +149,13 @@ public class ResponseTest {
                 HttpHeaders.Values.NO_STORE);
         assertEquals(response.headers().get(HttpHeaders.Names.PRAGMA), HttpHeaders.Values.NO_CACHE);
     }
+
+    @Test
+    public void when_no_message_in_response_set_content_length_zero() throws Exception {
+        // WHEN
+        HttpResponse response = Response.createResponse(HttpResponseStatus.OK, null);
+
+        // THEN
+        assertEquals(response.headers().get(HttpHeaders.Names.CONTENT_LENGTH), "0");
+    }
 }


### PR DESCRIPTION
[Issue #59] Add Content-Length header even if the response is empty