### PR TITLE
[Issue #66] Skip converting the body of a request to String

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.codec.binary.Base64;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
+import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -56,13 +57,12 @@ public class AuthorizationServer {
 
     public ClientCredentials issueClientCredentials(HttpRequest req) throws OAuthException {
         ClientCredentials creds = null;
-        String content = req.getContent().toString(CharsetUtil.UTF_8);
         String contentType = req.headers().get(HttpHeaders.Names.CONTENT_TYPE);
 
         if (contentType != null && contentType.contains(Response.APPLICATION_JSON)) {
             ApplicationInfo appInfo;
             try {
-                appInfo = InputValidator.validate(content, ApplicationInfo.class);
+                appInfo = InputValidator.validate(new ChannelBufferInputStream(req.getContent()), ApplicationInfo.class);
                 if (appInfo.valid()) {
                     String[] scopeList = appInfo.getScope().split(" ");
                     for (String s : scopeList) {
@@ -433,7 +433,6 @@ public class AuthorizationServer {
     }
 
     public boolean updateClientApp(HttpRequest req, String clientId) throws OAuthException {
-        String content = req.getContent().toString(CharsetUtil.UTF_8);
         String contentType = req.headers().get(HttpHeaders.Names.CONTENT_TYPE);
         if (contentType != null && contentType.contains(Response.APPLICATION_JSON)) {
 //            String clientId = getBasicAuthorizationClientId(req);
@@ -445,7 +444,7 @@ public class AuthorizationServer {
             }
             ApplicationInfo appInfo;
             try {
-                appInfo = InputValidator.validate(content, ApplicationInfo.class);
+                appInfo = InputValidator.validate(new ChannelBufferInputStream(req.getContent()), ApplicationInfo.class);
                 if (appInfo.validForUpdate()) {
                     if (appInfo.getScope() != null) {
                         String[] scopeList = appInfo.getScope().split(" ");

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/InputValidator.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/InputValidator.java
@@ -16,6 +16,7 @@
 package com.apifest.oauth20;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonParseException;
@@ -31,6 +32,8 @@ import org.codehaus.jackson.util.JsonParserDelegate;
  */
 public class InputValidator {
 
+    private static ObjectMapper mapper = new ObjectMapper();
+
     /**
      * Validates an input and returns an instance of a given class constructed from the input.
      * @param input the input to be validated
@@ -39,14 +42,14 @@ public class InputValidator {
      * @throws JsonParseException
      * @throws IOException
      */
-    public static <T> T validate(String input, final Class<T> clazz) throws JsonParseException, IOException {
-        ObjectMapper mapper = new ObjectMapper();
+    public static <T> T validate(InputStream input, final Class<T> clazz) throws JsonParseException, IOException {
         JsonFactory factory = mapper.getJsonFactory();
         JsonParser parser = null;
         T obj = null;
         parser = factory.createJsonParser(input);
         JsonParser parserWrapper = new JsonParserDelegate(parser) {
 
+            @Override
             public String getText() throws IOException, JsonParseException {
                 String str = delegate.getText();
                 try {

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeService.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/ScopeService.java
@@ -26,11 +26,11 @@ import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.QueryStringDecoder;
-import org.jboss.netty.util.CharsetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,13 +64,12 @@ public class ScopeService {
      * @return String message that will be returned in the response
      */
     public String registerScope(HttpRequest req) throws OAuthException {
-        String content = req.getContent().toString(CharsetUtil.UTF_8);
         String contentType = (req.headers() != null) ? req.headers().get(HttpHeaders.Names.CONTENT_TYPE) : null;
         String responseMsg = "";
         // check Content-Type
         if (contentType != null && contentType.contains(Response.APPLICATION_JSON)) {
             try {
-                Scope scope = InputValidator.validate(content, Scope.class);
+                Scope scope = InputValidator.validate(new ChannelBufferInputStream(req.getContent()), Scope.class);
                 if (scope.valid()) {
                     if (!Scope.validScopeName(scope.getScope())) {
                         log.error("scope name is not valid");
@@ -237,13 +236,12 @@ public class ScopeService {
      * @return String message that will be returned in the response
      */
     public String updateScope(HttpRequest req, String scopeName) throws OAuthException {
-        String content = req.getContent().toString(CharsetUtil.UTF_8);
         String contentType = (req.headers() != null) ? req.headers().get(HttpHeaders.Names.CONTENT_TYPE) : null;
         String responseMsg = "";
         // check Content-Type
         if (contentType != null && contentType.contains(Response.APPLICATION_JSON)) {
             try {
-                Scope scope = InputValidator.validate(content, Scope.class);
+                Scope scope = InputValidator.validate(new ChannelBufferInputStream(req.getContent()), Scope.class);
                 if (scope.validForUpdate()) {
                     Scope foundScope = DBManagerFactory.getInstance().findScope(scopeName);
                     if (foundScope == null) {

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/InputValidatorTest.java
@@ -19,6 +19,9 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 
+import java.io.ByteArrayInputStream;
+
+import org.jboss.netty.util.CharsetUtil;
 import org.testng.annotations.Test;
 
 /**
@@ -36,8 +39,10 @@ public class InputValidatorTest {
 
         String inputValue = "300";
 
+        String testString = "{\"" + Scope.JSON_CC_EXPIRES_IN + "\":\"" + inputValue + "\"}";
+
         // WHEN
-        InputValidator.validate("{\"" + Scope.JSON_CC_EXPIRES_IN + "\":\"" + inputValue + "\"}", Scope.class);
+        InputValidator.validate(new ByteArrayInputStream(testString.getBytes(CharsetUtil.UTF_8)), Scope.class);
 
         // THEN
         verify(ScopeValidator.getInstance()).validate(Scope.JSON_CC_EXPIRES_IN, inputValue);
@@ -53,7 +58,8 @@ public class InputValidatorTest {
         String inputValue = "1";
 
         // WHEN
-        InputValidator.validate("{\"" + ApplicationInfo.JSON_STATUS + "\":\"" + inputValue + "\"}", ApplicationInfo.class);
+        String testString = "{\"" + ApplicationInfo.JSON_STATUS + "\":\"" + inputValue + "\"}";
+        InputValidator.validate(new ByteArrayInputStream(testString.getBytes(CharsetUtil.UTF_8)), ApplicationInfo.class);
 
         // THEN
         verify(ApplicationInfoValidator.getInstance()).validate(ApplicationInfo.JSON_STATUS, inputValue);
@@ -64,6 +70,7 @@ public class InputValidatorTest {
     public void when_no_validator_do_not_throw_NPE() throws Exception {
 
         // WHEN
-        InputValidator.validate("{\"client_id\":\"123456\"}", ClientCredentials.class);
+        String testString = "{\"client_id\":\"123456\"}";
+        InputValidator.validate(new ByteArrayInputStream(testString.getBytes(CharsetUtil.UTF_8)), ClientCredentials.class);
     }
 }


### PR DESCRIPTION
Skip converting the body of a request to String before reading it.

Also do not create an object mapper on every call.