### PR TITLE
[Issue #80] Remove client_id from access token revoke service

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
@@ -400,11 +400,6 @@ public class AuthorizationServer {
     public boolean revokeToken(HttpRequest req) throws OAuthException {
         RevokeTokenRequest revokeRequest = new RevokeTokenRequest(req);
         revokeRequest.checkMandatoryParams();
-//        String clientId = revokeRequest.getClientId();
-//        // check valid client_id, status does not matter as token of inactive client app could be revoked too
-//        if (!isExistingClient(clientId)) {
-//            throw new OAuthException(Response.INVALID_CLIENT_ID, HttpResponseStatus.BAD_REQUEST);
-//        }
         String token = revokeRequest.getAccessToken();
         AccessToken accessToken = db.findAccessToken(token);
         if (accessToken != null) {
@@ -412,14 +407,9 @@ public class AuthorizationServer {
                 log.debug("access token {} is expired", token);
                 return true;
             }
-            //if (clientId.equals(accessToken.getClientId())) {
-                db.removeAccessToken(accessToken.getToken());
-                log.debug("access token {} set status invalid", token);
-                return true;
-            /*} else {
-                log.debug("access token {} is not obtained for that clientId {}", token, clientId);
-                return false;
-            }*/
+            db.removeAccessToken(accessToken.getToken());
+            log.debug("access token {} set status invalid", token);
+            return true;
         }
         log.debug("access token {} not found", token);
         return false;

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthorizationServer.java
@@ -400,11 +400,11 @@ public class AuthorizationServer {
     public boolean revokeToken(HttpRequest req) throws OAuthException {
         RevokeTokenRequest revokeRequest = new RevokeTokenRequest(req);
         revokeRequest.checkMandatoryParams();
-        String clientId = revokeRequest.getClientId();
-        // check valid client_id, status does not matter as token of inactive client app could be revoked too
-        if (!isExistingClient(clientId)) {
-            throw new OAuthException(Response.INVALID_CLIENT_ID, HttpResponseStatus.BAD_REQUEST);
-        }
+//        String clientId = revokeRequest.getClientId();
+//        // check valid client_id, status does not matter as token of inactive client app could be revoked too
+//        if (!isExistingClient(clientId)) {
+//            throw new OAuthException(Response.INVALID_CLIENT_ID, HttpResponseStatus.BAD_REQUEST);
+//        }
         String token = revokeRequest.getAccessToken();
         AccessToken accessToken = db.findAccessToken(token);
         if (accessToken != null) {
@@ -412,14 +412,14 @@ public class AuthorizationServer {
                 log.debug("access token {} is expired", token);
                 return true;
             }
-            if (clientId.equals(accessToken.getClientId())) {
+            //if (clientId.equals(accessToken.getClientId())) {
                 db.removeAccessToken(accessToken.getToken());
                 log.debug("access token {} set status invalid", token);
                 return true;
-            } else {
+            /*} else {
                 log.debug("access token {} is not obtained for that clientId {}", token, clientId);
                 return false;
-            }
+            }*/
         }
         log.debug("access token {} not found", token);
         return false;

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/HttpRequestHandler.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/HttpRequestHandler.java
@@ -318,8 +318,10 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
             invokeExceptionHandler(e, req);
             return Response.createOAuthExceptionResponse(e);
         }
-        String json = "{\"revoked\":\"" + revoked + "\"}";
-        HttpResponse response = Response.createOkResponse(json);
+        //String json = "{\"revoked\":\"" + revoked + "\"}";
+        JsonObject json = new JsonObject();
+        json.addProperty("revoked", revoked);
+        HttpResponse response = Response.createOkResponse(json.toString());
         return response;
     }
 

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/RevokeTokenRequest.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/RevokeTokenRequest.java
@@ -69,9 +69,5 @@ public class RevokeTokenRequest {
             throw new OAuthException(String.format(Response.MANDATORY_PARAM_MISSING, ACCESS_TOKEN),
                     HttpResponseStatus.BAD_REQUEST);
         }
-        if (clientId == null || clientId.isEmpty()) {
-            throw new OAuthException(String.format(Response.MANDATORY_PARAM_MISSING, CLIENT_ID),
-                    HttpResponseStatus.BAD_REQUEST);
-        }
     }
 }

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/RevokeTokenRequest.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/RevokeTokenRequest.java
@@ -34,6 +34,8 @@ public class RevokeTokenRequest {
     protected static final String CLIENT_ID = "client_id";
 
     private String accessToken;
+
+    //TODO: remove it, not used anymore
     private String clientId;
 
     public RevokeTokenRequest(HttpRequest request) {

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/HttpRequestHandlerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/HttpRequestHandlerTest.java
@@ -158,7 +158,7 @@ public class HttpRequestHandlerTest {
         HttpResponse response = handler.handleTokenRevoke(req);
 
         // THEN
-        assertEquals(response.getContent().toString(CharsetUtil.UTF_8), "{\"revoked\":\"true\"}");
+        assertEquals(response.getContent().toString(CharsetUtil.UTF_8), "{\"revoked\":true}");
     }
 
     @Test
@@ -173,7 +173,7 @@ public class HttpRequestHandlerTest {
         HttpResponse response = handler.handleTokenRevoke(req);
 
         // THEN
-        assertEquals(response.getContent().toString(CharsetUtil.UTF_8), "{\"revoked\":\"false\"}");
+        assertEquals(response.getContent().toString(CharsetUtil.UTF_8), "{\"revoked\":false}");
     }
 
     @Test

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/RevokeTokenRequestTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/RevokeTokenRequestTest.java
@@ -135,56 +135,6 @@ public class RevokeTokenRequestTest {
     }
 
     @Test
-    public void when_clientId_null_return_bad_request() throws Exception {
-        // GIVEN
-        HttpRequest req = mock(HttpRequest.class);
-        String content = "{\"access_token\":\"9376e098e8190835a0b41d83355f92d66f425469\"," +
-            "\"client_secret\":\"bb635eb22c5b5ce3de06e31bb88be7ae\"}";
-        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
-        willReturn(buf).given(req).getContent();
-        RevokeTokenRequest revokeTokenReq = new RevokeTokenRequest(req);
-
-        // WHEN
-        String errorMsg = null;
-        HttpResponseStatus status = null;
-        try {
-            revokeTokenReq.checkMandatoryParams();
-        } catch (OAuthException e){
-            errorMsg = e.getMessage();
-            status = e.getHttpStatus();
-        }
-
-        // THEN
-        assertEquals(errorMsg, String.format(Response.MANDATORY_PARAM_MISSING, RevokeTokenRequest.CLIENT_ID));
-        assertEquals(status, HttpResponseStatus.BAD_REQUEST);
-    }
-
-    @Test
-    public void when_clientId_empty_return_bad_request() throws Exception {
-        // GIVEN
-        HttpRequest req = mock(HttpRequest.class);
-        String content = "{\"access_token\":\"9376e098e8190835a0b41d83355f92d66f425469\"," +
-            "\"client_id\":\"\",\"client_secret\":\"bb635eb22c5b5ce3de06e31bb88be7ae\"}";
-        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
-        willReturn(buf).given(req).getContent();
-        RevokeTokenRequest revokeTokenReq = new RevokeTokenRequest(req);
-
-        // WHEN
-        String errorMsg = null;
-        HttpResponseStatus status = null;
-        try {
-            revokeTokenReq.checkMandatoryParams();
-        } catch (OAuthException e){
-            errorMsg = e.getMessage();
-            status = e.getHttpStatus();
-        }
-
-        // THEN
-        assertEquals(errorMsg, String.format(Response.MANDATORY_PARAM_MISSING, RevokeTokenRequest.CLIENT_ID));
-        assertEquals(status, HttpResponseStatus.BAD_REQUEST);
-    }
-
-    @Test
     public void when_invalid_JSON_return_revoke_request_with_null_values() throws Exception {
         // GIVEN
         HttpRequest req = mock(HttpRequest.class);


### PR DESCRIPTION
Remove client_id param from /tokens/revoke service.