### PR TITLE
Fixed client_secret missing if client_id is provided as body param

### DIFF
--- a/apifest-oauth20/pom.xml
+++ b/apifest-oauth20/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>2.12.4</version>
+      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>redis.clients</groupId>

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/MongoUtil.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/MongoUtil.java
@@ -39,18 +39,13 @@ public class MongoUtil {
 
     public static MongoClient getMongoClient() {
         if (mongoClient == null) {
-            try {
-                MongoClientOptions.Builder options = new MongoClientOptions.Builder()
-                        .connectionsPerHost(100).connectTimeout(2)
-                        .threadsAllowedToBlockForConnectionMultiplier(1);
-                final MongoClientURI mongoClientURI  = new MongoClientURI(OAuthServer.getDbURI(), options);
-                mongoClient = new MongoClient(mongoClientURI);
+            MongoClientOptions.Builder options = new MongoClientOptions.Builder().connectionsPerHost(100)
+                    .connectTimeout(2000).threadsAllowedToBlockForConnectionMultiplier(1);
+            final MongoClientURI mongoClientURI = new MongoClientURI(OAuthServer.getDbURI(), options);
+            mongoClient = new MongoClient(mongoClientURI);
 
-                if (mongoClientURI.getDatabase() != null) {
-                    database = mongoClientURI.getDatabase();
-                }
-            } catch (UnknownHostException e) {
-                log.error("Cannot connect to DB", e);
+            if (mongoClientURI.getDatabase() != null) {
+                database = mongoClientURI.getDatabase();
             }
         }
         return mongoClient;

--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/TokenRequest.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/TokenRequest.java
@@ -73,7 +73,7 @@ public class TokenRequest {
         this.redirectUri = params.get(REDIRECT_URI);
         this.clientId = params.get(CLIENT_ID);
         this.clientSecret = params.get(CLIENT_SECRET);
-        if (this.clientId == null && this.clientSecret == null) {
+        if (this.clientId == null || this.clientSecret == null) {
             String [] clientCredentials = AuthorizationServer.getBasicAuthorizationClientCredentials(request);
             this.clientId = clientCredentials [0];
             this.clientSecret = clientCredentials [1];


### PR DESCRIPTION
Sometimes OAuthClients do a TokenRequest with the client_id in the body (without the client_secret) and provide client_id and client_secret in the authorization header.

So the clientId would be !=null but the clientSecret == null.
In that case the authorization header won't be evaluated.

This pull request fixes this issue.