### PR TITLE
[Issue #56] redirect_uri should be optional in case of auth code generation

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthRequest.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/AuthRequest.java
@@ -95,7 +95,7 @@ public class AuthRequest {
             throw new OAuthException(Response.RESPONSE_TYPE_NOT_SUPPORTED,
                     HttpResponseStatus.BAD_REQUEST);
         }
-        if (!isValidURI(redirectUri)) {
+        if (redirectUri != null && !isValidURI(redirectUri)) {
             throw new OAuthException(Response.INVALID_REDIRECT_URI, HttpResponseStatus.BAD_REQUEST);
         }
     }

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/HttpRequestHandlerTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/HttpRequestHandlerTest.java
@@ -733,7 +733,7 @@ public class HttpRequestHandlerTest {
     }
 
     @Test
-    public void when_get_tokens_client_id_invalid_return_invalid_client_id() throws Exception {
+    public void when_get_tokens_client_id_is_invalid_return_invalid_client_id() throws Exception {
         // GIVEN
         HttpRequest req = mock(HttpRequest.class);
         String userId = "214331231";
@@ -741,7 +741,7 @@ public class HttpRequestHandlerTest {
         willReturn(HttpRequestHandler.ACCESS_TOKEN_URI + "?client_id=" + clientId + "&user_id=" + userId).given(req).getUri();
         AuthorizationServer auth = mock(AuthorizationServer.class);
         handler.auth = auth;
-        willReturn(false).given(handler.auth).isActiveClientId(clientId);
+        willReturn(false).given(handler.auth).isExistingClient(clientId);
 
 
         // WHEN


### PR DESCRIPTION
Redirect_uri should be optional, if no redirec_uri is passed used the one stored with the client application.