### PR TITLE
[Issue #94] When the pair client_id/client_secret is not provided in request body, check Authorization header

### DIFF
--- a/apifest-oauth20/src/main/java/com/apifest/oauth20/TokenRequest.java
+++ b/apifest-oauth20/src/main/java/com/apifest/oauth20/TokenRequest.java
@@ -21,10 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.util.CharsetUtil;
@@ -73,7 +71,8 @@ public class TokenRequest {
         this.redirectUri = params.get(REDIRECT_URI);
         this.clientId = params.get(CLIENT_ID);
         this.clientSecret = params.get(CLIENT_SECRET);
-        if (this.clientId == null && this.clientSecret == null) {
+        // if the pair client_id, client_secret is not set, check the Authorization header
+        if (this.clientId == null || this.clientSecret == null) {
             String [] clientCredentials = AuthorizationServer.getBasicAuthorizationClientCredentials(request);
             this.clientId = clientCredentials [0];
             this.clientSecret = clientCredentials [1];

--- a/apifest-oauth20/src/test/java/com/apifest/oauth20/TokenRequestTest.java
+++ b/apifest-oauth20/src/test/java/com/apifest/oauth20/TokenRequestTest.java
@@ -321,4 +321,44 @@ public class TokenRequestTest {
         assertNull(tokenReq.getClientId());
         assertNull(tokenReq.getClientSecret());
     }
+
+    @Test
+    public void when_client_secret_is_missing_then_get_client_id_and_client_secret_from_auth_basic_header() throws Exception {
+        // GIVEN
+        String content = "grant_type=client_credentials&client_id=b9db6d84dc98a895035e68f972e30503d3c724c8";
+        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
+        given(req.getContent()).willReturn(buf);
+        String basicHeader = "Basic YjlkYjZkODRkYzk4YTg5NTAzNWU2OGY5NzJlMzA1MDNkM2M3MjRjODoxMDVlZjkzZTd"
+                + "iYjM4NmRhM2EyM2MzMmU4NTYzNDM0ZmFkMDA1ZmQwYTZhODgzMTVmY2RmOTQ2YWE3NjFjODM4";
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set(HttpHeaders.Names.AUTHORIZATION, basicHeader);
+        given(req.headers()).willReturn(headers);
+
+        // WHEN
+        TokenRequest tokenReq = new TokenRequest(req);
+
+        // THEN
+        assertNotNull(tokenReq.getClientId());
+        assertNotNull(tokenReq.getClientSecret());
+    }
+
+    @Test
+    public void when_client_id_is_missing_then_get_client_id_and_client_secret_from_auth_basic_header() throws Exception {
+        // GIVEN
+        String content = "grant_type=client_credentials&client_secret=105ef93e7bb386da3a23c32e8563434fad005fd0a6a88315fcdf946aa761c838";
+        ChannelBuffer buf = ChannelBuffers.copiedBuffer(content.getBytes(CharsetUtil.UTF_8));
+        given(req.getContent()).willReturn(buf);
+        String basicHeader = "Basic YjlkYjZkODRkYzk4YTg5NTAzNWU2OGY5NzJlMzA1MDNkM2M3MjRjODoxMDVlZjkzZTd"
+                + "iYjM4NmRhM2EyM2MzMmU4NTYzNDM0ZmFkMDA1ZmQwYTZhODgzMTVmY2RmOTQ2YWE3NjFjODM4";
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set(HttpHeaders.Names.AUTHORIZATION, basicHeader);
+        given(req.headers()).willReturn(headers);
+
+        // WHEN
+        TokenRequest tokenReq = new TokenRequest(req);
+
+        // THEN
+        assertNotNull(tokenReq.getClientId());
+        assertNotNull(tokenReq.getClientSecret());
+    }
 }


### PR DESCRIPTION
The issue was originally raised by nilswieber:
"Sometimes OAuthClients do a TokenRequest with the client_id in the body (without the client_secret) and provide client_id and client_secret in the authorization header.

So the clientId would be !=null but the clientSecret == null.
In that case the authorization header won't be evaluated."